### PR TITLE
Fikset sidebar og innlasting av prosjekter når man laster inn dashboard

### DIFF
--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -1,32 +1,39 @@
 <template>
-  <div class="ProjectNameList" v-for = "entry in store.projects"><!--Liste som displayer navn på aktive prosjekt. Må endres senere.-->
-    <NuxtLink :project="entry" :to="`/projectList/${ entry.id }`">Project {{ entry.id }}</NuxtLink>
+  <div class="ProjectNameList">
+    <!-- Vise listene i sidebar -->
+    <NuxtLink v-for="project in projects" :key="project.id" :to="`/projectList/${project.id}`">
+      {{ project.title }}
+    </NuxtLink>
   </div>
 </template>
 
 <script setup>
-  import { useProjectsStore } from '@/stores/projects'
+import { useProjectsStore } from '@/stores/projects';
+import { ref, watchEffect } from 'vue';
 
-  const store = useProjectsStore();
+const store = useProjectsStore();
+const projects = ref([]);
+
+// ser etter endringer i projects tabell og legger deretter til ref([])
+watchEffect(() => {
+  projects.value = store.projects;
+});
+
 </script>
-
 <style scoped>
-
- /*Styling for listen.*/
-.ProjectNameList{
-    display: flex;
-    flex-direction: column;
-    margin: 0;
-    margin-left: 10px;
-    font-size: 20px;
+.ProjectNameList {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  margin-left: 10px;
+  font-size: 20px;
 }
 
-/* Hover og tekststyling */
-.ProjectNameList a{
+.ProjectNameList a {
   text-decoration: none;
   color: black;
 }
-.ProjectNameList a:hover{
+.ProjectNameList a:hover {
   text-decoration: none;
   color: grey;
 }

--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -16,7 +16,7 @@ const projects = ref([]);
 
 // ser etter endringer i projects tabell og legger deretter til ref([])
 watchEffect(() => {
-  projects.value = store.projects;
+  projects.value = store.getProjects();
 });
 
 </script>

--- a/components/ProjectList.vue
+++ b/components/ProjectList.vue
@@ -37,7 +37,7 @@
   // Initialiserer prosjectStore slik at man kan bruke den ved å kalle på store.
   const store = useProjectsStore();
   const gateStore = useGatesStore();
-  const projects = store.projects;
+  const projects = store.getProjects();
   const index = ref(0);
 
 

--- a/components/ProjectList.vue
+++ b/components/ProjectList.vue
@@ -37,8 +37,8 @@
   // Initialiserer prosjectStore slik at man kan bruke den ved å kalle på store.
   const store = useProjectsStore();
   const gateStore = useGatesStore();
-  const projects = ref([]);
-const index = ref(0);
+  const projects = store.projects;
+  const index = ref(0);
 
 
 const formData = ref({
@@ -63,34 +63,6 @@ const toggleModal = () => {
   modalActive.value = !modalActive.value;
 
 };
-  onMounted(async () => {
-  try {
-    const response = await $fetch('/projects', {
-      method: 'GET'
-    });
-    // Henter bare ut dataen i responsen, dropper "Hello World..."
-    const data = response.data;
-    // Transformerer data til en liste av projects
-  const projectsArray = Object.values(data).map(project => ({
-  id: project.ID,
-  title: project.title,
-  progress: project.progress,
-  onTime: project.onTime,
-  PEM: project.PEM,
-  comment: project.comment,
-  POdate: project.POdate,
-  SFdate: project.SFdate,
-  archive: project.archive,
-  gates: project.gates
-}));
-    // Oppdaterer projects ref med transformert data
-    projects.value = projectsArray;
-  } catch (error) {
-    console.error('Error fetching projects:', error);
-  }
-});
-
-
 </script>
 
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,7 +11,7 @@ import { useProjectsStore } from '@/stores/projects';
 const store = useProjectsStore();
 
 onMounted(() => {
-  if (store.projects.length === 0) {
+  if (store.getProjects().length === 0) {
     console.log('Dashboard mounted');
     store.fetchProjects();
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,3 +3,20 @@
     <h1>Welcome to the dashboard</h1>
   </div>
 </template>
+
+<script setup>
+import { onMounted } from 'vue';
+import { useProjectsStore } from '@/stores/projects';
+
+const store = useProjectsStore();
+
+onMounted(() => {
+  if (store.projects.length === 0) {
+    console.log('Dashboard mounted');
+    store.fetchProjects();
+  }
+  });
+  watchEffect(() => {
+  console.log(store.projects);
+  });
+</script>

--- a/stores/projects.js
+++ b/stores/projects.js
@@ -42,6 +42,9 @@ export const useProjectsStore = defineStore('projects', () => {
       console.error('Error fetching projects:', error);
     }
   }
+  	function getProjects() {
+		return projects.value;
+	}
 	
 	function getProjectById(projectId) {
 		console.log(projectId)
@@ -82,5 +85,5 @@ export const useProjectsStore = defineStore('projects', () => {
             });
         }
     }
-	return { project, projects, getProjectById, addProject, setProjects, fetchProjects}
+	return { project, projects, getProjects,getProjectById, addProject, setProjects, fetchProjects}
 });

--- a/stores/projects.js
+++ b/stores/projects.js
@@ -9,6 +9,39 @@ export const useProjectsStore = defineStore('projects', () => {
 	// listen av prosjekter
 	const projects = ref([]);
 	const index = ref (0)
+
+	function setProjects(newProjects) {
+		console.log("Legger til alt i store igjen")
+		projects.value = newProjects;
+	  }
+	
+	// hente og oppdatere prosjekter
+  	async function fetchProjects() {
+		console.log('Fetching projects...');
+    try {
+      const response = await $fetch('/projects', {
+        method: 'GET'
+      });
+
+      const data = response.data;
+      const projectsArray = Object.values(data).map(project => ({
+        id: project.ID,
+        title: project.title,
+        progress: project.progress,
+        onTime: project.onTime,
+        PEM: project.PEM,
+        comment: project.comment,
+        POdate: project.POdate,
+        SFdate: project.SFdate,
+        archive: project.archive,
+        gates: project.gates
+      }));
+
+      setProjects(projectsArray);
+    } catch (error) {
+      console.error('Error fetching projects:', error);
+    }
+  }
 	
 	function getProjectById(projectId) {
 		console.log(projectId)
@@ -17,7 +50,6 @@ export const useProjectsStore = defineStore('projects', () => {
 	}
 	// Funksjon for å legge til et prosjekt i listen
 	async function addProject(ID, title, progress, plannedDate, PODate, status, PEM, comment) {
-
 
         const requestBody = {
 			ID: ID,
@@ -50,5 +82,5 @@ export const useProjectsStore = defineStore('projects', () => {
             });
         }
     }
-	return { project, projects, getProjectById, addProject }
+	return { project, projects, getProjectById, addProject, setProjects, fetchProjects}
 });


### PR DESCRIPTION
Lagt til så sidebaren venter på endringer i project store, og laster inn når endringer er gjort. Dette skjer bare på dashboard. Så dersom man går rett på /projeclist  etter å ha refreshet laster ikke sidebar og prosjekter inn. Dersom man går frem og tilbake til dashboard flere ganger kalles ikke data fra databasen flere ganger. 